### PR TITLE
Support for Voice Over

### DIFF
--- a/QBPopupMenu/QBPopupMenuItemView.m
+++ b/QBPopupMenu/QBPopupMenuItemView.m
@@ -142,4 +142,23 @@
     }
 }
 
+#pragma mark - Accessibility
+
+- (BOOL)isAccessibilityElement {
+    return YES;
+}
+
+- (UIAccessibilityTraits)accessibilityTraits
+{
+    return UIAccessibilityTraitButton;
+}
+
+- (NSString *)accessibilityLabel {
+    if (_item.accessibilityLabel) {
+        return _item.accessibilityLabel;
+    }
+    
+    return _item.title;
+}
+
 @end


### PR DESCRIPTION
Set an accessibility label on QBPopupMenuItem (needed if item contains only image) :

QBPopupMenuItem *item = [QBPopupMenuItem itemWithImage:image target:self action:@selector(tappedImage:)]
item.accessibilityLabel = @"do something";
